### PR TITLE
Replaced all init() methods with one versatile and intuitive one

### DIFF
--- a/Sources/Hypertext.swift
+++ b/Sources/Hypertext.swift
@@ -55,22 +55,9 @@ open class tag: Renderable {
     public var children: Renderable? = nil
     public var attributes: [String: String] = [:]
 
-    public init(setChildren: (() -> Renderable?)) {
-        self.children = setChildren()
-    }
-
-    public convenience init() {
-        self.init { nil }
-    }
-
-    public convenience init(attributes: [String: String]) {
-        self.init { nil }
+    public init(_ attributes: [String: String] = [:], setChildren: (() -> Renderable?) = { nil }) {
         self.attributes = attributes
-    }
-
-    public convenience init(setChildren: (() -> Renderable?), attributes: [String: String]) {
-        self.init(setChildren: setChildren)
-        self.attributes = attributes
+        self.children   = setChildren()
     }
 
     public func render() -> String {

--- a/Sources/Hypertext.swift
+++ b/Sources/Hypertext.swift
@@ -52,7 +52,7 @@ open class tag: Renderable {
     public var name: String? = nil
     public var isSelfClosing: Bool = false
     public var children: Renderable? = nil
-    public var attributes: [String: String]? = [:]
+    public var attributes: [String: String] = [:]
 
     public init(setChildren: (() -> Renderable?)) {
         self.children = setChildren()
@@ -80,7 +80,7 @@ open class tag: Renderable {
         if isSelfClosing {
             return "<\(name)\(renderAttributes())/>"
         } else {
-            return "<\(name)\(renderAttributes())>\(children != nil ? children!.render() : "")</\(name)>"
+            return "<\(name)\(renderAttributes())>\(children?.render() ?? "")</\(name)>"
         }
     }
 
@@ -101,10 +101,6 @@ open class tag: Renderable {
     }
 
     private func renderAttributes() -> String {
-        guard let attributes = attributes else {
-            return ""
-        }
-
         return attributes.keys.reduce("") { renderedSoFar, attributeKey in
             return "\(renderedSoFar) \(attributeKey)=\"\(attributes[attributeKey]!)\""
         }

--- a/Tests/HypertextTests/HypertextTests.swift
+++ b/Tests/HypertextTests/HypertextTests.swift
@@ -96,14 +96,14 @@ class HypertextTests: XCTestCase {
 
   func testCanRenderAttributeOnTag() {
       let expected = "<link href=\"./style.css\"/>"
-      let actual = link(attributes: ["href":"./style.css"]).render()
+      let actual = link(["href":"./style.css"]).render()
 
       XCTAssertEqual(expected, actual)
   }
 
   func testCanRenderAttributeOnNestedTag() {
       let expected = "<head><link href=\"./style.css\"/></head>"
-      let actual = head { link(attributes: ["href":"./style.css"]) }.render()
+      let actual = head { link(["href":"./style.css"]) }.render()
     
       XCTAssertEqual(expected, actual)
   }


### PR DESCRIPTION
This does everything I mentioned in #8. I actually added two more init() methods initially which utilised `@autoclosure`, but I removed them, because I thought they might be confusing.

Now it's very consistent, attributes go between parentheses `()` and children go between curly brackets `{}`. And attributes always go before children, just like in HTML. And both arguments have a default value so you don't need to make the `convenience init()` methods.

## edit

I just assumed I should merge this to the 2.0 branch. Is that correct? Otherwise I'll open a new PR for the master branch.