### PR TITLE
Adding support for default hyphenation of tag names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ head { title { "hello world." } }.render(startingWithSpaces: 0, indentingWithSpa
    }
    
    myNewTag().render()
-   // <myNewTag/>
+   // <my-new-tag/>
    
    ```
    

--- a/Sources/Hypertext.swift
+++ b/Sources/Hypertext.swift
@@ -66,7 +66,12 @@ enum TagFormatter {
     
     static private func delimited(_ tag: String, delimiter: String) -> String {
         let range = NSMakeRange(0, tag.characters.count)
-        let regex = try! NSRegularExpression(pattern: "(.)(?=[A-Z])", options: [])
+        let pattern = "(.)(?=[A-Z])"
+        #if !os(Linux)
+        let regex = try! NSRegularExpression(pattern: pattern, options: [])
+        #else
+        let regex = try! RegularExpression(pattern: pattern, options: [])
+        #endif
         return regex.stringByReplacingMatches(in: tag, options: [], range: range, withTemplate: "$1\(delimiter)").lowercased()
     }
 }

--- a/Sources/Hypertext.swift
+++ b/Sources/Hypertext.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Sahand Nayebaziz. All rights reserved.
 //
 
+import Foundation
+
 public protocol Renderable: CustomStringConvertible {
     func render() -> String
     func render(startingWithSpaces: Int, indentingWithSpaces: Int) -> String
@@ -54,9 +56,27 @@ extension Array: Renderable {
     }
 }
 
+enum TagFormatter {
+    static func dashed(_ tag: String) -> String {
+        return delimited(tag, delimiter: "-")
+    }
+    static func snaked(_ tag: String) -> String {
+        return delimited(tag, delimiter: "_")
+    }
+    
+    static private func delimited(_ tag: String, delimiter: String) -> String {
+        let range = NSMakeRange(0, tag.characters.count)
+        let regex = try! NSRegularExpression(pattern: "(.)(?=[A-Z])", options: [])
+        return regex.stringByReplacingMatches(in: tag, options: [], range: range, withTemplate: "$1\(delimiter)").lowercased()
+    }
+}
+
 open class tag: Renderable {
     open var isSelfClosing: Bool { return false }
-    open var name: String { return String(describing: type(of: self)) }
+    open var name: String {
+        let typeName = String(describing: type(of: self))
+        return TagFormatter.dashed(typeName)
+    }
 
     public var children: Renderable? = nil
     public var attributes: [String: String] = [:]

--- a/Tests/HypertextTests/HypertextTests.swift
+++ b/Tests/HypertextTests/HypertextTests.swift
@@ -1,6 +1,17 @@
 import XCTest
 @testable import Hypertext
 
+//MARK: Test Tags
+
+class materialButton: tag {}
+class camelButton: tag {
+  override public var name: String {
+    return String(describing: type(of: self))
+  }
+}
+
+//MARK: Test Cases
+
 class HypertextTests: XCTestCase {
 
   func testCanRenderString() {
@@ -165,6 +176,38 @@ class HypertextTests: XCTestCase {
 
       XCTAssertEqual(expectedHtml4, actualHtml4)
   }
+  
+  func testSnakeDelimiter() {
+    let expected = "material_button"
+    let actual = TagFormatter.snaked("materialButton")
+    XCTAssertEqual(expected, actual)
+    
+    let expectedNoOp = "materialbutton"
+    let actualNoOp = TagFormatter.snaked("materialbutton")
+    XCTAssertEqual(expectedNoOp, actualNoOp)
+  }
+  
+  func testDashDelimiter() {
+    let expected = "material-button"
+    let actual = TagFormatter.dashed("materialButton")
+    XCTAssertEqual(expected, actual)
+    
+    let expectedNoOp = "materialbutton"
+    let actualNoOp = TagFormatter.dashed("materialbutton")
+    XCTAssertEqual(expectedNoOp, actualNoOp)
+  }
+  
+  func testDefaultTagFormatIsDashed() {
+    let expected = "<material-button></material-button>"
+    let actual = materialButton().render()
+    XCTAssertEqual(expected, actual)
+  }
+  
+  func testCanOverrideDefaultTagFormat() {
+    let expected = "<camelButton></camelButton>"
+    let actual = camelButton().render()
+    XCTAssertEqual(expected, actual)
+  }
 
   static var allTests : [(String, (HypertextTests) -> () throws -> Void)] {
     return [
@@ -188,7 +231,11 @@ class HypertextTests: XCTestCase {
         ("testCanCreateCustomTagWithOverridenName", testCanCreateCustomTagWithOverridenName),
         ("testCanRenderTagWithAttributesAndChildren", testCanRenderTagWithAttributesAndChildren),
         ("testCanDescribeTagAsCustomStringConvertible", testCanDescribeTagAsCustomStringConvertible),
-        ("testCanRenderDoctype", testCanRenderDoctype)
+        ("testCanRenderDoctype", testCanRenderDoctype),
+        ("testSnakeDelimiter", testSnakeDelimiter),
+        ("testDashDelimiter", testDashDelimiter),
+        ("testDefaultTagFormatIsDashed", testDefaultTagFormatIsDashed),
+        ("testCanOverrideDefaultTagFormat", testCanOverrideDefaultTagFormat)
     ]
   }
 


### PR DESCRIPTION
Implements #11. For custom tags defined like `class materialButton: tag {}` we now, by default, render a tag like `<material-button></material-button>`. This is still overridable using the same mechanism as before.